### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/explorer855/.Net9App/security/code-scanning/1](https://github.com/explorer855/.Net9App/security/code-scanning/1)

The best way to fix this issue is to explicitly define the `permissions` key in the workflow. Since the workflow involves building Docker images and running tests, it likely only requires `contents: read` permission for accessing repository files. If additional write permissions (e.g., for `issues` or `pull-requests`) are needed, they should be added only as required.

The fix involves adding a `permissions` block at the root of the workflow file, which will apply to all jobs. Alternatively, you could add a `permissions` block specifically to the `build` job if granular control is preferred. Here, we will apply permissions at the root level for simplicity and consistency.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
